### PR TITLE
Add concatenation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # cinema : a lightweight video editing library for Go
 
-
 ![alt text](https://i.imgur.com/uYRpL29.jpg "github.com/jtguibas/cinema")
 
 ## Overview [![GoDoc](https://godoc.org/github.com/jtguibas/cinema?status.svg)](https://godoc.org/github.com/jtguibas/cinema)
@@ -8,9 +7,11 @@
 cinema is a simple video editing library based on ffmpeg. It supports trimming, resizing, cropping, concatenation and more. Use it to create videos directly or let it generate command lines that use ffmpeg for you.
 
 ## Installation
+
 You must have [FFMPEG](https://ffmpeg.org/download.html) installed on your machine! Make sure `ffmpeg` and `ffprobe` are available from the command line on your machine.
 To install `cinema` run:
-```
+
+```bash
 go get github.com/jtguibas/cinema
 ```
 
@@ -18,30 +19,30 @@ go get github.com/jtguibas/cinema
 
 ```golang
 func main() {
-	downloadTestVideo("example.mp4")
+    downloadTestVideo("example.mp4")
 
-	video, err := cinema.Load("example.mp4")
-	check(err)
+    video, err := cinema.Load("example.mp4")
+    heck(err)
 
-	video.Trim(10*time.Second, 20*time.Second) // trim video from 10 to 20 seconds
-	video.SetStart(1 * time.Second)            // trim first second of the video
-	video.SetEnd(9 * time.Second)              // keep only up to 9 seconds
-	video.SetSize(400, 300)                    // resize video to 400x300
-	video.Crop(0, 0, 200, 200)                 // crop rectangle top-left (0,0) with size 200x200
-	video.SetSize(400, 400)                    // resize cropped 200x200 video to a 400x400
-	video.SetFPS(48)                           // set the output framerate to 48 frames per second
-	video.Render("test_output.mov")            // note format conversion by file extension
+    video.Trim(10*time.Second, 20*time.Second) // trim video from 10 to 20 seconds
+    video.SetStart(1 * time.Second)            // trim first second of the video
+    video.SetEnd(9 * time.Second)              // keep only up to 9 seconds
+    video.SetSize(400, 300)                    // resize video to 400x300
+    video.Crop(0, 0, 200, 200)                 // crop rectangle top-left (0,0) with size 200x200
+    video.SetSize(400, 400)                    // resize cropped 200x200 video to a 400x400
+    video.SetFPS(48)                           // set the output framerate to 48 frames per second
+    video.Render("test_output.mov")            // note format conversion by file extension
 
-	// you can also generate the command line instead of applying it directly
-	fmt.Println("FFMPEG Command", video.CommandLine("test_output.mov"))
+    // you can also generate the command line instead of applying it directly
+    fmt.Println("FFMPEG Command", video.CommandLine("test_output.mov"))
 
-	// produce another test video and concatenate both clips
-	video.Trim(42*time.Second, 48*time.Second)
-	video.Render("test_output2.mov")
-	clip, err := cinema.NewClip([]string{"test_output1.mov", "test_output2.mov"})
-	check(err)
-	clip.Concatenate("concat.mov")
-	fmt.Println("FFMPEG Command", clip.CommandLine("concat.mov"))
+    // produce another test video and concatenate both clips
+    video.Trim(42*time.Second, 48*time.Second)
+    video.Render("test_output2.mov")
+    clip, err := cinema.NewClip([]string{"test_output1.mov", "test_output2.mov"})
+    check(err)
+    clip.Concatenate("concat.mov")
+    fmt.Println("FFMPEG Command", clip.CommandLine("concat.mov"))
 }
 ```
 
@@ -52,11 +53,11 @@ func main() {
 - [x] add concatenation support
 - [x] improve godoc documentation
 - [x] add cropping support
-- [x] test ubuntu support 
+- [x] test ubuntu support
 - [x] implement fps support
 
 Feel free to open pull requests!
 
 ## Acknowledgments
-- Big thanks to [gonutz](https://github.com/gonutz) for contributing to this project!
 
+- Big thanks to [gonutz](https://github.com/gonutz) for contributing to this project!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![alt text](https://i.imgur.com/uYRpL29.jpg "github.com/jtguibas/cinema")
 
-## Overview [![GoDoc](https://godoc.org/github.com/jtguibas/cinema?status.svg)](https://godoc.org/github.com/jtguibas/cinema)
+## Overview [![GoDoc](https://godoc.org/github.com/cfanatic/cinema?status.svg)](https://godoc.org/github.com/cfanatic/cinema)
 
 cinema is a simple video editing library based on ffmpeg. It supports trimming, resizing, cropping, concatenation and more. Use it to create videos directly or let it generate command lines that use ffmpeg for you.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview [![GoDoc](https://godoc.org/github.com/jtguibas/cinema?status.svg)](https://godoc.org/github.com/jtguibas/cinema)
 
-cinema is a simple video editing library based on ffmpeg. It supports trimming, resizing, cropping and more. Use it to create videos directly or let it generate command lines that use ffmpeg for you.
+cinema is a simple video editing library based on ffmpeg. It supports trimming, resizing, cropping, concatenation and more. Use it to create videos directly or let it generate command lines that use ffmpeg for you.
 
 ## Installation
 You must have [FFMPEG](https://ffmpeg.org/download.html) installed on your machine! Make sure `ffmpeg` and `ffprobe` are available from the command line on your machine.
@@ -34,18 +34,26 @@ func main() {
 
 	// you can also generate the command line instead of applying it directly
 	fmt.Println("FFMPEG Command", video.CommandLine("test_output.mov"))
+
+	// produce another test video and concatenate both clips
+	video.Trim(42*time.Second, 48*time.Second)
+	video.Render("test_output2.mov")
+	clip, err := cinema.NewClip([]string{"test_output1.mov", "test_output2.mov"})
+	check(err)
+	clip.Concatenate("concat.mov")
+	fmt.Println("FFMPEG Command", clip.CommandLine("concat.mov"))
 }
 ```
 
 ## TODO
 
-- [ ] add concatenation support
+- [ ] expand to audio
+- [ ] implement bitrate support
+- [x] add concatenation support
 - [x] improve godoc documentation
 - [x] add cropping support
-- [ ] expand to audio
-- [ ] test ubuntu support 
+- [x] test ubuntu support 
 - [x] implement fps support
-- [ ] implement bitrate support
 
 Feel free to open pull requests!
 

--- a/cinema.go
+++ b/cinema.go
@@ -32,7 +32,7 @@ type Video struct {
 
 // TODO
 type Clip struct {
-	videosPath       []string
+	videosPath      []string
 	concatListCache string
 }
 
@@ -308,6 +308,19 @@ func (v *Video) Bitrate() int {
 // TODO
 func NewClip(videoPath []string) (*Clip, error) {
 	var clip Clip
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		return nil, errors.New("cinema.Load: ffprobe was not found in your PATH " +
+			"environment variable, make sure to install ffmpeg " +
+			"(https://ffmpeg.org/) and add ffmpeg, ffplay and ffprobe to your " +
+			"PATH")
+	}
+
+	for _, path := range videoPath {
+		if _, err := os.Stat(path); err != nil {
+			return nil, errors.New("cinema.Load: unable to load file: " + err.Error())
+		}
+	}
+
 	dir := filepath.Dir(videoPath[0])
 	clip = Clip{videosPath: videoPath, concatListCache: filepath.Join(dir, "concat.txt")}
 	return &clip, nil

--- a/cinema.go
+++ b/cinema.go
@@ -28,7 +28,12 @@ type Video struct {
 	duration       time.Duration
 	filters        []string
 	additionalArgs []string
-	concatInput     string
+}
+
+// TODO
+type Clip struct {
+	fileListPath     []string
+	concatInputCache string
 }
 
 // Load gives you a Video that can be operated on. Load does not open the file
@@ -184,61 +189,6 @@ func (v *Video) CommandLine(output string) []string {
 	return cmdline
 }
 
-// TODO
-func (v *Video) Concatenate(clips []string, output string) error {
-	return v.ConcatenateWithStreams(clips, output, nil, nil)
-}
-
-// TODO
-func (v *Video) ConcatenateWithStreams(clips []string, output string, os io.Writer, es io.Writer) error {
-	v.saveConcatenateList(clips)
-	defer v.deleteConcatenateList()
-	line := v.CommandLineConcatenate(clips, output)
-	cmd := exec.Command(line[0], line[1:]...)
-	cmd.Stderr = es
-	cmd.Stdout = os
-
-	err := cmd.Run()
-	if err != nil {
-		return errors.New("cinema.Video.Concatenate: ffmpeg failed: " + err.Error())
-	}
-	return nil
-}
-
-// TODO
-func (v *Video) CommandLineConcatenate(clips []string, output string) []string {
-	cmdline := []string{
-		"ffmpeg",
-		"-y",
-		"-f", "concat",
-		"-i", v.concatInput,
-		"-c", "copy",
-	}
-	cmdline = append(cmdline, "-fflags", "+genpts", filepath.Join(filepath.Dir(clips[0]), output))
-	return cmdline
-}
-
-func (v *Video) saveConcatenateList(clips []string) error {
-	dir := filepath.Dir(clips[0])
-	v.concatInput = filepath.Join(dir, "concat.txt")
-	f, err := os.Create(v.concatInput)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	for _, clip := range clips {
-		fmt.Fprintf(f, "file '%s'\n", filepath.Base(clip))
-	}
-	return nil
-}
-
-func (v *Video) deleteConcatenateList() error {
-	if err := os.Remove(v.concatInput); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Mute mutes the video
 func (v *Video) Mute() {
 	v.additionalArgs = append(v.additionalArgs, "-an")
@@ -353,4 +303,59 @@ func (v *Video) FPS() int {
 // Bitrate returns the set bitrate of the current video struct
 func (v *Video) Bitrate() int {
 	return v.bitrate
+}
+
+// TODO
+func (c *Clip) Concatenate(clip []string, output string) error {
+	return c.ConcatenateWithStreams(clip, output, nil, nil)
+}
+
+// TODO
+func (c *Clip) ConcatenateWithStreams(clip []string, output string, os io.Writer, es io.Writer) error {
+	c.saveConcatenateList(clip)
+	defer c.deleteConcatenateList()
+	line := c.CommandLineConcatenate(clip, output)
+	cmd := exec.Command(line[0], line[1:]...)
+	cmd.Stderr = es
+	cmd.Stdout = os
+
+	err := cmd.Run()
+	if err != nil {
+		return errors.New("cinema.Video.Concatenate: ffmpeg failed: " + err.Error())
+	}
+	return nil
+}
+
+// TODO
+func (c *Clip) CommandLineConcatenate(clip []string, output string) []string {
+	cmdline := []string{
+		"ffmpeg",
+		"-y",
+		"-f", "concat",
+		"-i", c.concatInputCache,
+		"-c", "copy",
+	}
+	cmdline = append(cmdline, "-fflags", "+genpts", filepath.Join(filepath.Dir(clip[0]), output))
+	return cmdline
+}
+
+func (c *Clip) saveConcatenateList(clip []string) error {
+	dir := filepath.Dir(clip[0])
+	c.concatInputCache = filepath.Join(dir, "concat.txt")
+	f, err := os.Create(c.concatInputCache)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, clip := range clip {
+		fmt.Fprintf(f, "file '%s'\n", filepath.Base(clip))
+	}
+	return nil
+}
+
+func (c *Clip) deleteConcatenateList() error {
+	if err := os.Remove(c.concatInputCache); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cinema.go
+++ b/cinema.go
@@ -30,7 +30,9 @@ type Video struct {
 	additionalArgs []string
 }
 
-// TODO
+// Clip contains the absolute or relative path to video files that shall be concatenated.
+// Call Clip.NewClip() to initialize the video files and run Clip.Concatenate() to produce
+// a single video file.
 type Clip struct {
 	videosPath      []string
 	concatListCache string
@@ -305,7 +307,8 @@ func (v *Video) Bitrate() int {
 	return v.bitrate
 }
 
-// TODO
+// NewClip gives you a Clip that can be used to concatenate video files.
+// Provide a list of absolute or relative paths to these videos by videoPath.
 func NewClip(videoPath []string) (*Clip, error) {
 	var clip Clip
 	if _, err := exec.LookPath("ffprobe"); err != nil {
@@ -326,12 +329,15 @@ func NewClip(videoPath []string) (*Clip, error) {
 	return &clip, nil
 }
 
-// TODO
+// Concatenate produces a single video clip based on Clip.videosPath and save it as output.
+// This method won't return anything on stdout / stderr.
+// If you need to read ffmpeg's outputs, use RenderWithStreams.
 func (c *Clip) Concatenate(output string) error {
 	return c.ConcatenateWithStreams(output, nil, nil)
 }
 
-// TODO
+// ConcatenateWithStreams produces a single video clip based on Clip.videosPath and save it as output.
+// By specifying an output stream and an error stream, you can read ffmpeg's stdout and stderr.
 func (c *Clip) ConcatenateWithStreams(output string, os io.Writer, es io.Writer) error {
 	c.saveConcatenateList()
 	defer c.deleteConcatenateList()
@@ -347,7 +353,7 @@ func (c *Clip) ConcatenateWithStreams(output string, os io.Writer, es io.Writer)
 	return nil
 }
 
-// TODO
+// CommandLine returns the command line instruction that will be used to concatenate the video files.
 func (c *Clip) CommandLine(output string) []string {
 	cmdline := []string{
 		"ffmpeg",

--- a/cinema.go
+++ b/cinema.go
@@ -288,12 +288,12 @@ func (v *Video) Duration() time.Duration {
 	return v.duration
 }
 
-// Get the set fps of the current video struct
+// FPS returns the set fps of the current video struct
 func (v *Video) FPS() int {
 	return v.fps
 }
 
-// Get the set bitrate of the current video struct
+// Bitrate returns the set bitrate of the current video struct
 func (v *Video) Bitrate() int {
 	return v.bitrate
 }

--- a/example/example.go
+++ b/example/example.go
@@ -24,10 +24,18 @@ func main() {
 	video.SetSize(400, 400)                    // resize cropped 200x200 video to a 400x400
 	video.SetFPS(48)                           // set the output framerate to 48 frames per second
 	video.SetBitrate(200_000)                  // set the output bitrate of 200 kbps
-	video.Render("test_output.mov")            // note format conversion by file extension
+	video.Render("test_output1.mov")           // note format conversion by file extension
 
 	// you can also generate the command line instead of applying it directly
-	fmt.Println("FFMPEG Command", video.CommandLine("test_output.mov"))
+	fmt.Println("FFMPEG Command", video.CommandLine("test_output1.mov"))
+
+	// produce another test video and concatenate both clips
+	video.Trim(42*time.Second, 48*time.Second)
+	video.Render("test_output2.mov")
+	clip, err := cinema.NewClip([]string{"test_output1.mov", "test_output2.mov"}) // absolute or relative paths can be used
+	check(err)
+	clip.Concatenate("concat.mov")
+	fmt.Println("FFMPEG Command", clip.CommandLine("concat.mov"))
 }
 
 func downloadTestVideo(to string) {


### PR DESCRIPTION
Hi,

It is now possible to concatenate multiple video into a single clip. I have tested it for MP4 and MOV on both Debian and macOS.

Output of the example:

```
$ go run example/example.go
downloading test video...
FFMPEG Command [ffmpeg -y -i example.mp4 -ss 1 -t 8 -vb 200000 -vf scale=400:300,crop=200:200:0:0,scale=400:400,setsar=1,fps=fps=48 -strict -2 test_output1.mov]
FFMPEG Command [ffmpeg -y -f concat -i concat.txt -c copy -fflags +genpts concat.mov]
```

Cheers,
Arnd